### PR TITLE
In sparse tensor initialization, fix shape inference from the index arrays

### DIFF
--- a/sktensor/sptensor.py
+++ b/sktensor/sptensor.py
@@ -87,7 +87,7 @@ class sptensor(tensor_mixin):
         self.dtype = dtype
 
         if shape is None:
-            self.shape = tuple(array(subs).max(axis=1).flatten())
+            self.shape = tuple(array(subs).max(axis=1).flatten() + 1)
         else:
             self.shape = tuple(int(d) for d in shape)
         self.ndim = len(subs)

--- a/sktensor/tests/test_sptensor.py
+++ b/sktensor/tests/test_sptensor.py
@@ -19,6 +19,17 @@ def mysetup():
     return tuple(subs), vals, shape
 
 
+def setup_diagonal():
+    """
+    Setup data for a 20x20x20 diagonal tensor
+    """
+    n = 20
+    shape = (n, n, n)
+    subs = [np.arange(0, shape[i]) for i in xrange(len(shape))]
+    vals = ones(n)
+    return tuple(subs), vals, shape
+
+
 def test_init():
     """
     Creation of new sptensor objects
@@ -29,9 +40,20 @@ def test_init():
     assert_true((array(shape) == T.shape).all())
 
     T = sptensor(subs, vals)
-    tshape = array(subs).max(axis=1)
+    tshape = array(subs).max(axis=1) + 1
     assert_equal(len(subs), len(T.shape))
     assert_true((tshape == array(T.shape)).all())
+
+
+def test_init_diagonal():
+    subs, vals, shape = setup_diagonal()
+    T = sptensor(subs, vals, shape)
+    assert_equal(len(shape), T.ndim)
+    assert_true((array(shape) == T.shape).all())
+
+    T = sptensor(subs, vals)
+    assert_equal(len(subs), len(T.shape))
+    assert_true((shape == array(T.shape)).all())
 
 
 @raises(ValueError)


### PR DESCRIPTION
This pull request should fix the tensor shape inference when creating a sparse tensor.
When inferring the shape of the tensor from the maximum values of the subs arrays, the shape values must be incremented by 1 in order to fit a 0-based index array.
