### PR TITLE
[MRG] Fixes #6 : python 3.4 where range returns iterator instead of list

### DIFF
--- a/sktensor/cp.py
+++ b/sktensor/cp.py
@@ -142,7 +142,7 @@ def als(X, rank, **kwargs):
         for n in range(N):
             Unew = X.uttkrp(U, n)
             Y = ones((rank, rank), dtype=dtype)
-            for i in (range(n) + range(n + 1, N)):
+            for i in (list(range(n)) + list(range(n + 1, N))):
                 Y = Y * dot(U[i].T, U[i])
             Unew = Unew.dot(pinv(Y))
             # Normalize

--- a/sktensor/dtensor.py
+++ b/sktensor/dtensor.py
@@ -159,7 +159,7 @@ class dtensor(tensor_mixin, np.ndarray):
 
     @inherit_docstring_from(tensor_mixin)
     def uttkrp(self, U, n):
-        order = range(n) + range(n + 1, self.ndim)
+        order = list(range(n)) + list(range(n + 1, self.ndim))
         Z = khatrirao(tuple(U[i] for i in order), reverse=True)
         return self.unfold(n).dot(Z)
 


### PR DESCRIPTION
Quick changes for Python 3.4 support

Tests pass except for two failures (which are also outstanding in master) with Python 3.4 and Python 2.7
