### PR TITLE
Use setuptools install_requires instead of pkg_resources.require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ descr = """Python module for multilinear algebra and tensor factorizations"""
 
 import os
 import sys
-from pkg_resources import require
 
 DISTNAME = 'scikit-tensor'
 DESCRIPTION = descr
@@ -43,8 +42,6 @@ try:
 except:
     print('setuptools module not found.')
     print("Install setuptools if you want to enable 'python setup.py develop'.")
-
-require('numpy', 'scipy', 'nose')
 
 
 def configuration(parent_package='', top_path=None, package_name=DISTNAME):
@@ -103,6 +100,11 @@ def setup_package():
         download_url=DOWNLOAD_URL,
         long_description=LONG_DESCRIPTION,
         version=get_version(),
+        install_requires=[
+            'numpy',
+            'scipy',
+            'nose'
+        ],
         #test_suite="nose.collector",
         cmdclass=cmdclass,
         **EXTRA_INFO


### PR DESCRIPTION
This PR enables `scikit-tensor` to install without user interaction. Instead of failing during install

    pip install scikit-tensor

will now automatically install `numpy`, `scipy` and `nose`, if not already installed.