### PR TITLE
Prevent leakage of filehandler in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from pkg_resources import require
 
 DISTNAME = 'scikit-tensor'
 DESCRIPTION = descr
-LONG_DESCRIPTION = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
+    LONG_DESCRIPTION = f.read()
 MAINTAINER = 'Maximilian Nickel',
 MAINTAINER_EMAIL = 'mnick@mit.edu',
 URL = 'http://github.com/mnick/scikit-tensor'


### PR DESCRIPTION
This PR fixes a small issue of leaking the filehandler created by `open()` in `setup.py`. None of the remaining behaviour was changed.