### PR TITLE
Install dev requirements optionally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+scipy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+nose

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,14 @@ def get_version():
     return mod.__version__
 
 
+with open('requirements.txt') as f:
+    INSTALL_REQUIRES = [
+        x.strip('\n')
+        for x in f.readlines()
+        if x and x[0] != '#'
+    ]
+
+
 def setup_package():
 # Call the setup function
     metadata = dict(
@@ -83,11 +91,7 @@ def setup_package():
         download_url=DOWNLOAD_URL,
         long_description=LONG_DESCRIPTION,
         version=get_version(),
-        install_requires=[
-            'numpy',
-            'scipy',
-            'nose'
-        ],
+        install_requires=INSTALL_REQUIRES,
         #test_suite="nose.collector",
         **EXTRA_INFO
     )


### PR DESCRIPTION
Dev packages (i.e. nose) should not be required for the installation, because this package is needed for development purposes only. Therefore, I create two different files, i.e. `requirements.txt` which holds the required packages, and `requirements_dev.txt` which includes packages needed for development.

If someone needs development packages, then explicitly:

```
pip install -r requirements_dev.txt
```